### PR TITLE
Improve descriptions, help texts, error messages, etc

### DIFF
--- a/shuup_category_organizer/admin_module/views.py
+++ b/shuup_category_organizer/admin_module/views.py
@@ -84,10 +84,10 @@ class CategoryOrganizeView(BaseCategoryView):
             Category.objects.rebuild()
 
             if not request.is_ajax():
-                messages.success(request, _("Categories saved"))
+                messages.success(request, _("Categories saved."))
         else:
             if not request.is_ajax():
-                messages.error(request, _("Payload is missing from the request"))
+                messages.error(request, _("Payload is missing from the request."))
 
         return self.get(request)
 
@@ -99,7 +99,7 @@ class CategoryDuplicateView(BaseCategoryView):
         category = Category.objects.filter(shops=get_shop(request), pk=kwargs["pk"]).first()
 
         if not category:
-            raise Http404(_("Category doesn't exist"))
+            raise Http404(_("Category doesn't exist."))
 
         new_category = Category.objects.create(
             parent=category.parent,

--- a/shuup_category_organizer/static_src/scripts.js
+++ b/shuup_category_organizer/static_src/scripts.js
@@ -206,7 +206,7 @@ window.saveCategories = function () {
     addLoader();
     saveCategories(true, () => {
         $("#loader").remove();
-        Messages.enqueue({ tags: "success", text: gettext("Categories saved") });
+        Messages.enqueue({ tags: "success", text: gettext("Success! Categories were saved.") });
     });
 };
 


### PR DESCRIPTION
This is part of a big update to improve various texts in Shuup.

A lot of changes, touching almost every individual Shuup project's repo.

There are too many changes to try to describe them separately, but the 
main ones are:
1. Improve `help_text` descriptions. Fix typos, rewrite and change, 
write new ones.
2. Change some of the model field names (for example rename 
`available_from` -> `available_since`; `available_to` `available_until` 
- this is in a separate commit).
3. Improve some of the documentation.
4. Improve some in-code-comments.
5. Improve `settings.py` files. It's now clearer what each option does.
6. Change some of the naming.
7. Change the error/message system.

The main Shuup repo's Merge Request is here: 
https://github.com/shuup/shuup/pull/2113 (with a reasoning behind 
changes).